### PR TITLE
[fix/trivial] Improve BidTooLowPenalty estimate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+.aider*

--- a/src/services/scoring.ts
+++ b/src/services/scoring.ts
@@ -1,0 +1,12 @@
+export type ScoringValidator = {
+  epoch: number
+  voteAccount: string
+  revShare: {
+    bidTooLowPenaltyPmpe: number
+  }
+}
+
+export const fetchScoring = async (): Promise<ScoringValidator[]> => {
+    const res = await fetch(`https://scoring.marinade.finance/api/v1/scores/sam?lastEpochs=10`);
+    return res.json();
+};

--- a/src/services/scoring.ts
+++ b/src/services/scoring.ts
@@ -7,6 +7,6 @@ export type ScoringValidator = {
 }
 
 export const fetchScoring = async (): Promise<ScoringValidator[]> => {
-    const res = await fetch(`https://scoring.marinade.finance/api/v1/scores/sam?lastEpochs=10`);
+    const res = await fetch(`https://scoring.marinade.finance/api/v1/scores/sam?lastEpochs=3`);
     return res.json();
 };

--- a/src/services/validator-with-protected_event.ts
+++ b/src/services/validator-with-protected_event.ts
@@ -53,11 +53,14 @@ export const fetchProtectedEventsWithValidator = async (): Promise<ProtectedEven
         continue
       }
       const validator = validatorsMap[entry.voteAccount] ?? null
-      const epochStats = validator.epoch_stats.find(({ epoch }) => epoch == entry.epoch)
+      const epochStats = validator?.epoch_stats.find(({ epoch }) => epoch == entry.epoch)
       if (epochStats == null) {
         continue
       }
-      const penalty = (Number(epochStats.marinade_native_stake ?? "0") + Number(epochStats.marinade_stake ?? "0")) * entry.revShare.bidTooLowPenaltyPmpe / 1000
+      const penalty = (
+        Number(epochStats.marinade_native_stake ?? "0")
+          + Number(epochStats.marinade_stake ?? "0")
+      ) * entry.revShare.bidTooLowPenaltyPmpe / 1000
       if (penalty > 0) {
         const protectedEvent = {
           epoch: entry.epoch,
@@ -74,10 +77,13 @@ export const fetchProtectedEventsWithValidator = async (): Promise<ProtectedEven
       }
     }
 
-    if (maxStatsEpoch> maxScoredEpoch) {
+    if (maxStatsEpoch > maxScoredEpoch) {
       for (const entry of auctionResult.auctionData.validators) {
         const validator = validatorsMap[entry.voteAccount] ?? null
-        const penalty = (Number(validator?.marinade_native_stake ?? "0") + Number(validator?.marinade_stake ?? "0")) * entry.revShare.bidTooLowPenaltyPmpe / 1000
+        const penalty = (
+          Number(validator?.marinade_native_stake ?? "0")
+            + Number(validator?.marinade_stake ?? "0")
+        ) * entry.revShare.bidTooLowPenaltyPmpe / 1000
         if (penalty > 0) {
           const protectedEvent = {
             epoch: maxStatsEpoch,

--- a/src/services/validator-with-protected_event.ts
+++ b/src/services/validator-with-protected_event.ts
@@ -16,7 +16,7 @@ export type ProtectedEventWithValidator = {
 const LAST_DRYRUN_EPOCH = 608
 
 export const fetchProtectedEventsWithValidator = async (): Promise<ProtectedEventWithValidator[]> => {
-  const [{ validators }, { protected_events }, { auctionResult }, scoring] = await Promise.all([fetchValidatorsWithEpochs(3), fetchProtectedEvents(), loadSam(), fetchScoring()])
+  const [{ validators }, { protected_events }, scoring, { auctionResult }] = await Promise.all([fetchValidatorsWithEpochs(3), fetchProtectedEvents(), fetchScoring(), loadSam()])
 
     const estimatedProtectedEvents = await calculateProtectedEventEstimates(validators)
 
@@ -37,6 +37,13 @@ export const fetchProtectedEventsWithValidator = async (): Promise<ProtectedEven
         if (protectedEvent.epoch > latestProcessedEpoch) {
             protectedEventsWithValidator.push({ status: ProtectedEventStatus.ESTIMATE, protectedEvent, validator: validatorsMap[protectedEvent.vote_account] ?? null })
         }
+    }
+
+    let maxStatsEpoch = -Infinity
+    for (const validator of validators) {
+      for (const stat of validator.epoch_stats) {
+        maxStatsEpoch = Math.max(maxStatsEpoch, stat.epoch)
+      }
     }
 
     let maxScoredEpoch = 0
@@ -64,13 +71,6 @@ export const fetchProtectedEventsWithValidator = async (): Promise<ProtectedEven
           protectedEvent,
           validator,
         })
-      }
-    }
-
-    let maxStatsEpoch = -Infinity
-    for (const validator of validators) {
-      for (const stat of validator.epoch_stats) {
-        maxStatsEpoch = Math.max(maxStatsEpoch, stat.epoch)
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -5,7 +5,7 @@ import HtmlWebpackPlugin from "html-webpack-plugin";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin";
 
-const webpackConfig = (env): Configuration => ({
+const webpackConfig = (env: {production: boolean, development: boolean}): Configuration => ({
     entry: "./src/index.tsx",
     ...(env.production || !env.development ? {} : { devtool: "eval-source-map" }),
     resolve: {


### PR DESCRIPTION
Estimates and displays the BidTooLowPenalty for the epoch before and after it has been calculated and appeared in the scoring api output.