### PR TITLE
Bond commissions sort  [GEN-6558] 

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -95,7 +95,12 @@ export const Table: <Item>(props: Props<Item>) => JSX.Element = ({ data, columns
         items.sort((a, b) => {
             for (const [columnIndex, orderDirection] of order) {
                 const compareResult = columns[columnIndex].compare(a, b)
-                if (compareResult !== 0) {
+                if (compareResult !== undefined && compareResult !== 0) {
+                    // Handle special null values - Infinity means "a is null, always goes to end"
+                    if (compareResult === Infinity) return 1
+                    // -Infinity means "b is null, always goes to end"
+                    if (compareResult === -Infinity) return -1
+                    // Normal comparison - apply sort direction
                     return orderDirection === OrderDirection.ASC ? compareResult : -compareResult
                 }
             }

--- a/src/components/validator-bonds-table/validator-bonds-table.tsx
+++ b/src/components/validator-bonds-table/validator-bonds-table.tsx
@@ -124,15 +124,15 @@ export const ValidatorBondsTable: React.FC<Props> = ({ data, level }) => {
     </div>
 };
 
-function compareBondCommissions(a: BondRecord, b: BondRecord): number {
-  const aVal = a?.inflation_commission_bps
-  const bVal = b?.inflation_commission_bps
+function compareBondCommissions({bond: aBond}: ValidatorWithBond, {bond: bBond} : ValidatorWithBond): number | undefined {
+  const aVal = aBond?.inflation_commission_bps
+  const bVal = bBond?.inflation_commission_bps
   // Both null/undefined - equal
   if (aVal == null && bVal == null) return 0
-  // Only a is null - push to end
-  if (aVal == null) return 1
-  // Only b is null - push to end
-  if (bVal == null) return -1
+  // Only a is null - always push to end (use Infinity so it stays at end regardless of sort direction)
+  if (aVal == null) return Infinity
+  // Only b is null - always push to end (use -Infinity so it stays at end regardless of sort direction)
+  if (bVal == null) return -Infinity
   // Both have values - normal numeric sort
   return aVal - bVal
 }


### PR DESCRIPTION
Sorting for commission in bond does not work.  This is a fix.

To that. I would like the results to be like `0, 0, 1, 2, 3, undefined/null`, and in reverse `3, 2, 1, 0, 0, undefined/null`. I don’t want `undefined/null` to be sorted to the top at any time.