### PR TITLE
[sam] adding commission pmpe tooltip [GEN-7092]

### DIFF
--- a/src/components/sam-table/sam-table.tsx
+++ b/src/components/sam-table/sam-table.tsx
@@ -28,6 +28,9 @@ import {
   formattedOnChainMevCommission,
   formattedInBondMevCommission,
   formattedOnChainCommission,
+  selectMevCommissionPmpe,
+  selectCommissionPmpe,
+  selectBlockRewardsCommissionPmpe,
 } from 'src/services/sam'
 
 import styles from './sam-table.module.css'
@@ -211,7 +214,8 @@ export const SamTable: React.FC<Props> = ({
             cellAttrsFn: validator =>
               tooltipAttributes(
                 `On chain commission: ${formattedOnChainCommission(validator)}<br/>` +
-                  `In-bond commission: ${formattedInBondCommission(validator)}`,
+                  `In-bond commission: ${formattedInBondCommission(validator)}<br/>` +
+                  `Effective inflation commission PMPE: ${selectCommissionPmpe(validator)}`,
               ),
             render: validator => (
               <>{formatPercentage(selectCommission(validator), 0)}</>
@@ -224,7 +228,8 @@ export const SamTable: React.FC<Props> = ({
             cellAttrsFn: validator =>
               tooltipAttributes(
                 `On chain commission: ${formattedOnChainMevCommission(validator)}<br/>` +
-                  `In-bond commission: ${formattedInBondMevCommission(validator)}`,
+                  `In-bond commission: ${formattedInBondMevCommission(validator)}<br/>` +
+                  `Effective MEV commission PMPE: ${selectMevCommissionPmpe(validator)}`,
               ),
             render: validator => <>{formattedMevCommission(validator)}</>,
             compare: (a, b) =>
@@ -236,6 +241,10 @@ export const SamTable: React.FC<Props> = ({
             headerAttrsFn: () =>
               tooltipAttributes(
                 'Block rewards commission can be in Bond configuration solely.',
+              ),
+            cellAttrsFn: validator =>
+              tooltipAttributes(
+                `Effective block rewards commission PMPE: ${selectBlockRewardsCommissionPmpe(validator)}`,
               ),
             render: validator => (
               <>{formattedBlockRewardsCommission(validator)}</>

--- a/src/services/sam.ts
+++ b/src/services/sam.ts
@@ -206,6 +206,9 @@ export const formattedOnChainCommission = (
     : formatPercentage(onChainCommission, 0)
 }
 
+export const selectCommissionPmpe = (validator: AuctionValidator) =>
+  validator.revShare.inflationPmpe
+
 export const selectMevCommission = (
   validator: AuctionValidator,
 ): number | null => validator.mevCommissionDec
@@ -236,6 +239,9 @@ export const formattedOnChainMevCommission = (
     : formatPercentage(onChainMevCommission, 0)
 }
 
+export const selectMevCommissionPmpe = (validator: AuctionValidator) =>
+  validator.revShare.mevPmpe
+
 export const selectBlockRewardsCommission = (
   validator: AuctionValidator,
 ): number | null => validator.blockRewardsCommissionDec
@@ -258,6 +264,9 @@ export const formattedInBondBlockRewardsCommission = (
     ? '-'
     : formatPercentage(inBondBlockRewardsCommission, 0)
 }
+
+export const selectBlockRewardsCommissionPmpe = (validator: AuctionValidator) =>
+  validator.revShare.blockPmpe
 
 export const selectBondSize = (validator: AuctionValidator) =>
   validator.bondBalanceSol


### PR DESCRIPTION
I would like to add the PMPE tooltip value for the commission configuration. That should help validators understand what PMPE the commission setup approximately contributes to the auction mix.