### PR TITLE
[fix] missing validator from sam entry [trivial]

### DIFF
--- a/src/services/validator-with-protected_event.ts
+++ b/src/services/validator-with-protected_event.ts
@@ -86,7 +86,7 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
     const epochStats = validator?.epoch_stats.find(
       ({ epoch }) => epoch === entry.epoch,
     )
-    if (epochStats === null) {
+    if (epochStats == null) {
       continue
     }
     const penalty =


### PR DESCRIPTION
The "Protected Event" tab does not work at https://psr.marinade.finance/

The code expects the validator to be undefined, but a later check requires only `null`. This is a bug introduced by refactoring, introducing the linting following the Marinade standards.
https://github.com/marinade-finance/psr-dashboard/commit/9c20982855cb0f7ab37fe2af71b4ae460673ad3d#diff-1b54b8c9a8fe3b6dab99536165ace2ee8a7ee54f2d82a1a4bb2c880292eaf548L57

That was unfortunate.