### PR TITLE
[penalty] bid too low to be shown [SUP-104]

### DIFF
--- a/SCREENS.md
+++ b/SCREENS.md
@@ -75,6 +75,7 @@ Columns: Epoch, Validator, Name, Settlement, Reason, Funder.
 Default sort: Epoch desc, Settlement desc, Reason desc.
 
 Badges in Settlement column:
+
 - **Estimate** (green) — pending settlement, may change
 - **Dryrun** (dark) — test event, not claimable
 

--- a/public/docs/GUIDE.md
+++ b/public/docs/GUIDE.md
@@ -9,8 +9,8 @@ It displays DS SAM max yield auction results, validator bonds on-chain, and prot
 
 The dashboard aggregates data from multiple Marinade APIs:
 
-| API                  | Endpoint                                                                                                     | Purpose                                                                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| API                  | Endpoint                                                                                                     | Purpose                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
 | Validators API       | [`validators-api.marinade.finance/validators`](https://validators-api.marinade.finance/docs)                 | Validator information, commissions, stake amounts (updated once per hour)   |
 | Validator Bonds API  | [`validator-bonds-api.marinade.finance/bonds`](https://validator-bonds-api.marinade.finance/docs)            | Bond balances, configurations, commission overrides (updated once per hour) |
 | Protected Events API | [`validator-bonds-api.marinade.finance/protected-events`](https://validator-bonds-api.marinade.finance/docs) | Settlement claims and protected event history (updated once per epoch)      |
@@ -102,17 +102,17 @@ Both methods can be combined. The effective bid combines all components to deter
 
 ### Table Columns
 
-| Column         | Description                                                             |
-| -------------- | ----------------------------------------------------------------------- |
-| **Validator**  | Vote account public key                                                 |
+| Column         | Description                                                              |
+| -------------- | ------------------------------------------------------------------------ |
+| **Validator**  | Vote account public key                                                  |
 | **Infl.**      | Inflation commission - percentage of inflation rewards kept by validator |
 | **MEV**        | MEV commission - percentage of MEV rewards kept by validator             |
 | **Block**      | Block rewards commission - percentage of block rewards kept by validator |
-| **St. Bid**    | Static bid per 1000 SOL set in bond configuration                       |
-| **Bond**       | Current bond balance in SOL                                             |
+| **St. Bid**    | Static bid per 1000 SOL set in bond configuration                        |
+| **Bond**       | Current bond balance in SOL                                              |
 | **Max APY**    | Maximum APY offered based on validator's bid and commission settings     |
-| **SAM Active** | Currently active stake delegated by SAM                                 |
-| **SAM Target** | Target stake based on auction results                                   |
+| **SAM Active** | Currently active stake delegated by SAM                                  |
+| **SAM Target** | Target stake based on auction results                                    |
 | **Eff. Bid**   | Effective bid combining static bid and commission settings               |
 
 ### Participation Requirements

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -187,7 +187,8 @@
     <script>
       const content = document.getElementById('content')
       const tabs = document.querySelector('.tabs')
-      const expert = new URLSearchParams(location.search).get('from') === 'expert'
+      const expert =
+        new URLSearchParams(location.search).get('from') === 'expert'
 
       if (expert) {
         document.getElementById('back').href = '/expert-'
@@ -202,14 +203,19 @@
         content.innerHTML = 'loading...'
         fetch(name + '.md')
           .then(r => r.text())
-          .then(md => { content.innerHTML = marked.parse(md) })
-          .catch(() => { content.innerHTML = '<p>Error loading doc</p>' })
+          .then(md => {
+            content.innerHTML = marked.parse(md)
+          })
+          .catch(() => {
+            content.innerHTML = '<p>Error loading doc</p>'
+          })
         history.replaceState(null, '', '#' + name)
       }
 
       function activateTab(doc) {
-        tabs.querySelectorAll('.tab').forEach(t =>
-          t.classList.toggle('active', t.dataset.doc === doc))
+        tabs
+          .querySelectorAll('.tab')
+          .forEach(t => t.classList.toggle('active', t.dataset.doc === doc))
         loadDoc(doc)
       }
 

--- a/src/components/sam-table/sam-table.module.css
+++ b/src/components/sam-table/sam-table.module.css
@@ -1,10 +1,6 @@
 .simulationBanner {
   padding: 16px 32px;
-  background: linear-gradient(
-    135deg,
-    rgba(15, 25, 60, 1),
-    rgba(40, 45, 80, 1)
-  );
+  background: linear-gradient(135deg, rgba(15, 25, 60, 1), rgba(40, 45, 80, 1));
   color: #93c5fd;
   font-size: 18px;
   font-weight: 600;

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,10 @@
   box-sizing: border-box;
 }
 
-button, input, select, textarea {
+button,
+input,
+select,
+textarea {
   font-family: inherit;
 }
 

--- a/src/services/validator-with-protected_event.ts
+++ b/src/services/validator-with-protected_event.ts
@@ -79,7 +79,14 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
   let maxScoredEpoch = 0
   for (const entry of scoring) {
     maxScoredEpoch = Math.max(entry.epoch, maxScoredEpoch)
+  }
+
+  const auctionCoversCurrentEpoch = maxStatsEpoch >= maxScoredEpoch
+  for (const entry of scoring) {
     if (entry.epoch <= latestProcessedEpoch) {
+      continue
+    }
+    if (auctionCoversCurrentEpoch && entry.epoch === maxScoredEpoch) {
       continue
     }
     const validator = validatorsMap[entry.voteAccount] ?? null

--- a/src/services/validator-with-protected_event.ts
+++ b/src/services/validator-with-protected_event.ts
@@ -110,7 +110,7 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
     }
   }
 
-  if (maxStatsEpoch > maxScoredEpoch) {
+  if (maxStatsEpoch >= maxScoredEpoch) {
     for (const entry of auctionResult.auctionData.validators) {
       const validator = validatorsMap[entry.voteAccount] ?? null
       const penalty =


### PR DESCRIPTION
Consider fix for

```
## Bug

When a validator drops their bid mid-epoch, the PSR dashboard fails to show
a pending BidTooLow estimate even though the auction reruns fresh on every page load.

## Root cause

In `src/services/validator-with-protected_event.ts`, the fresh auction result
is only used for BidTooLow estimates in the fallback path (line 113):

  if (maxStatsEpoch > maxScoredEpoch) {
    // use fresh auction result for BidTooLow estimates
  }

When maxStatsEpoch === maxScoredEpoch (scoring is current), this path is skipped.
The code falls back to scoring data computed before the bid drop → bidTooLowPenaltyPmpe = 0 → no estimate shown.

sam.ts does run a fully fresh auction on every load (inputsSource: APIS,
cacheInputs: false) and correctly computes a non-zero bidTooLowPenaltyPmpe —
but that result is unused.

## Example

Validator 5BAi9YGCipHq4ZcXuen5vagRQqRTVTRszXNqBZC6uBPZ (0base.vc) dropped
bid from 0.082 → 0.030 PMPE mid-epoch 943. Fresh auction computes a penalty,
but dashboard shows nothing for epoch 943.

## Fix

Remove the maxStatsEpoch > maxScoredEpoch guard for BidTooLow, or add a
second pass that uses the fresh auction result for current-epoch estimates
regardless of scoring state.
```