### PR TITLE
[protected-events] surface SAM auction penalties [GEN-7373]

### DIFF
--- a/src/components/sam-table/sam-table.module.css
+++ b/src/components/sam-table/sam-table.module.css
@@ -1,7 +1,34 @@
 .penaltyBadge {
-  margin-left: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-left: 3px;
+  padding: 0;
+  border-radius: 4px;
+  font-family: sans-serif;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 700;
   cursor: help;
-  font-size: 36px;
+  vertical-align: middle;
+  user-select: none;
+}
+
+.penalty_bidLow {
+  background-color: rgba(239, 68, 68, 0.18);
+  color: #f87171;
+}
+
+.penalty_blacklist {
+  background-color: rgba(156, 163, 175, 0.2);
+  color: #d1d5db;
+}
+
+.penalty_risk {
+  background-color: rgba(234, 179, 8, 0.18);
+  color: #facc15;
 }
 
 .simulationBanner {

--- a/src/components/sam-table/sam-table.module.css
+++ b/src/components/sam-table/sam-table.module.css
@@ -1,7 +1,7 @@
 .penaltyBadge {
   margin-left: 4px;
   cursor: help;
-  font-size: 12px;
+  font-size: 36px;
 }
 
 .simulationBanner {

--- a/src/components/sam-table/sam-table.module.css
+++ b/src/components/sam-table/sam-table.module.css
@@ -1,3 +1,9 @@
+.penaltyBadge {
+  margin-left: 4px;
+  cursor: help;
+  font-size: 12px;
+}
+
 .simulationBanner {
   padding: 16px 32px;
   background: linear-gradient(135deg, rgba(15, 25, 60, 1), rgba(40, 45, 80, 1));

--- a/src/components/sam-table/sam-table.module.css.d.ts
+++ b/src/components/sam-table/sam-table.module.css.d.ts
@@ -12,6 +12,7 @@ interface CssExports {
   'metricRow': string;
   'metricWrap': string;
   'orderCell': string;
+  'penaltyBadge': string;
   'positionImproved1': string;
   'positionImproved2': string;
   'positionImproved3': string;

--- a/src/components/sam-table/sam-table.module.css.d.ts
+++ b/src/components/sam-table/sam-table.module.css.d.ts
@@ -13,6 +13,9 @@ interface CssExports {
   'metricWrap': string;
   'orderCell': string;
   'penaltyBadge': string;
+  'penalty_bidLow': string;
+  'penalty_blacklist': string;
+  'penalty_risk': string;
   'positionImproved1': string;
   'positionImproved2': string;
   'positionImproved3': string;

--- a/src/components/sam-table/sam-table.tsx
+++ b/src/components/sam-table/sam-table.tsx
@@ -58,10 +58,22 @@ import type { PendingEdits } from 'src/pages/sam'
 
 type ValidatorWithBondState = AuctionValidator & { bondState?: Color }
 
+type PenaltyKind = 'bidLow' | 'blacklist' | 'risk'
+
+const penaltyClass: Record<PenaltyKind, string> = {
+  bidLow: styles.penalty_bidLow,
+  blacklist: styles.penalty_blacklist,
+  risk: styles.penalty_risk,
+}
+
 const renderPenaltyBadges = (v: AuctionValidator) => {
   const stakeSol = v.marinadeActivatedStakeSol
-  const badges: { icon: string; label: string; sol: number; kind: string }[] =
-    []
+  const badges: {
+    icon: string
+    label: string
+    sol: number
+    kind: PenaltyKind
+  }[] = []
   const bidTooLowSol = (stakeSol * v.revShare.bidTooLowPenaltyPmpe) / 1000
   const blacklistSol = (stakeSol * v.revShare.blacklistPenaltyPmpe) / 1000
   const bondRiskSol = v.values?.bondRiskFeeSol ?? 0
@@ -92,7 +104,7 @@ const renderPenaltyBadges = (v: AuctionValidator) => {
       {...tooltipAttributes(
         `<b>${b.label}</b><br/>${formatSolAmount(b.sol, 3)} SOL (estimate)`,
       )}
-      className={`${styles.penaltyBadge} ${styles[`penalty_${b.kind}`]}`}
+      className={`${styles.penaltyBadge} ${penaltyClass[b.kind]}`}
     >
       {b.icon}
     </span>

--- a/src/components/sam-table/sam-table.tsx
+++ b/src/components/sam-table/sam-table.tsx
@@ -60,25 +60,41 @@ type ValidatorWithBondState = AuctionValidator & { bondState?: Color }
 
 const renderPenaltyBadges = (v: AuctionValidator) => {
   const stakeSol = v.marinadeActivatedStakeSol
-  const badges: { emoji: string; label: string; sol: number }[] = []
+  const badges: { icon: string; label: string; sol: number; kind: string }[] =
+    []
   const bidTooLowSol = (stakeSol * v.revShare.bidTooLowPenaltyPmpe) / 1000
   const blacklistSol = (stakeSol * v.revShare.blacklistPenaltyPmpe) / 1000
   const bondRiskSol = v.values?.bondRiskFeeSol ?? 0
   if (bidTooLowSol > 0)
-    badges.push({ emoji: '⬇️', label: 'BidTooLow', sol: bidTooLowSol })
+    badges.push({
+      icon: '▼',
+      label: 'BidTooLow',
+      sol: bidTooLowSol,
+      kind: 'bidLow',
+    })
   if (blacklistSol > 0)
-    badges.push({ emoji: '🚫', label: 'Blacklist', sol: blacklistSol })
+    badges.push({
+      icon: '⊘',
+      label: 'Blacklist',
+      sol: blacklistSol,
+      kind: 'blacklist',
+    })
   if (bondRiskSol > 0)
-    badges.push({ emoji: '💸', label: 'BondRiskFee', sol: bondRiskSol })
+    badges.push({
+      icon: '⚠',
+      label: 'BondRiskFee',
+      sol: bondRiskSol,
+      kind: 'risk',
+    })
   return badges.map(b => (
     <span
       key={b.label}
       {...tooltipAttributes(
         `<b>${b.label}</b><br/>${formatSolAmount(b.sol, 3)} SOL (estimate)`,
       )}
-      className={styles.penaltyBadge}
+      className={`${styles.penaltyBadge} ${styles[`penalty_${b.kind}`]}`}
     >
-      {b.emoji}
+      {b.icon}
     </span>
   ))
 }

--- a/src/components/sam-table/sam-table.tsx
+++ b/src/components/sam-table/sam-table.tsx
@@ -57,6 +57,32 @@ import type {
 import type { PendingEdits } from 'src/pages/sam'
 
 type ValidatorWithBondState = AuctionValidator & { bondState?: Color }
+
+const renderPenaltyBadges = (v: AuctionValidator) => {
+  const stakeSol = v.marinadeActivatedStakeSol
+  const badges: { emoji: string; label: string; sol: number }[] = []
+  const bidTooLowSol = (stakeSol * v.revShare.bidTooLowPenaltyPmpe) / 1000
+  const blacklistSol = (stakeSol * v.revShare.blacklistPenaltyPmpe) / 1000
+  const bondRiskSol = v.values?.bondRiskFeeSol ?? 0
+  if (bidTooLowSol > 0)
+    badges.push({ emoji: '⬇️', label: 'BidTooLow', sol: bidTooLowSol })
+  if (blacklistSol > 0)
+    badges.push({ emoji: '🚫', label: 'Blacklist', sol: blacklistSol })
+  if (bondRiskSol > 0)
+    badges.push({ emoji: '💸', label: 'BondRiskFee', sol: bondRiskSol })
+  return badges.map(b => (
+    <span
+      key={b.label}
+      {...tooltipAttributes(
+        `<b>${b.label}</b><br/>${formatSolAmount(b.sol, 3)} SOL (estimate)`,
+      )}
+      className={styles.penaltyBadge}
+    >
+      {b.emoji}
+    </span>
+  ))
+}
+
 type DisplayValidator = { validator: ValidatorWithBondState; isGhost: boolean }
 type EditField =
   | 'inflationCommission'
@@ -612,11 +638,14 @@ export const SamTable: React.FC<Props> = ({
               const va = selectVoteAccount(item.validator)
               const sim = !item.isGhost && simulatedValidator === va
               return (
-                <span
-                  className={`${styles.pubkey} ${sim ? styles.pubkeySimulated : ''}`}
-                >
-                  {va}
-                </span>
+                <>
+                  <span
+                    className={`${styles.pubkey} ${sim ? styles.pubkeySimulated : ''}`}
+                  >
+                    {va}
+                  </span>
+                  {renderPenaltyBadges(item.validator)}
+                </>
               )
             },
             compare: (a, b) =>

--- a/src/services/protected-events.ts
+++ b/src/services/protected-events.ts
@@ -81,12 +81,6 @@ export const isProtectedEvent = (
 ): e is ProtectedEventSettlement =>
   typeof e === 'object' && 'ProtectedEvent' in e
 
-const PENALTY_LABELS: Record<string, string> = {
-  BidTooLowPenalty: 'BidTooLow',
-  BlacklistPenalty: 'Blacklist',
-  BondRiskFee: 'Bond Risk Fee',
-}
-
 export type ProtectedEvent = {
   epoch: number
   amount: number
@@ -115,10 +109,9 @@ export const selectProtectedStakeReason = (protectedEvent: ProtectedEvent) => {
       return `Uptime ${formatPercentage(reason.DowntimeRevenueImpact.actual_credits / reason.DowntimeRevenueImpact.expected_credits)}`
     }
   }
-  if (typeof protectedEvent.reason === 'string') {
-    const label = PENALTY_LABELS[protectedEvent.reason]
-    if (label) return label
-  }
+  if (protectedEvent.reason === 'BidTooLowPenalty') return 'BidTooLow'
+  if (protectedEvent.reason === 'BlacklistPenalty') return 'Blacklist'
+  if (protectedEvent.reason === 'BondRiskFee') return 'Bond Risk Fee'
   console.log('unsupported event:', protectedEvent)
   return 'Unsupported'
 }

--- a/src/services/protected-events.ts
+++ b/src/services/protected-events.ts
@@ -53,16 +53,15 @@ export type ProtectedEventReason =
   | DowntimeRevenueImpactReason
   | CommissionSamIncreaseReason
 
-export const isCommissionIncreaseReason = (
+const isCommissionIncreaseReason = (
   e: ProtectedEventReason,
 ): e is CommissionIncreaseReason => 'CommissionIncrease' in e
-export const isLowCreditsReason = (
-  e: ProtectedEventReason,
-): e is LowCreditsReason => 'LowCredits' in e
-export const isDowntimeRevenueImpactReason = (
+const isLowCreditsReason = (e: ProtectedEventReason): e is LowCreditsReason =>
+  'LowCredits' in e
+const isDowntimeRevenueImpactReason = (
   e: ProtectedEventReason,
 ): e is DowntimeRevenueImpactReason => 'DowntimeRevenueImpact' in e
-export const isCommissionSamIncreaseReason = (
+const isCommissionSamIncreaseReason = (
   e: ProtectedEventReason,
 ): e is CommissionSamIncreaseReason => 'CommissionSamIncrease' in e
 
@@ -81,12 +80,12 @@ export const isProtectedEvent = (
   e: SettlementReason,
 ): e is ProtectedEventSettlement =>
   typeof e === 'object' && 'ProtectedEvent' in e
-export const isBidTooLowPenalty = (e: SettlementReason): boolean =>
-  e === 'BidTooLowPenalty'
-export const isBlacklistPenalty = (e: SettlementReason): boolean =>
-  e === 'BlacklistPenalty'
-export const isBondRiskFee = (e: SettlementReason): boolean =>
-  e === 'BondRiskFee'
+
+const PENALTY_LABELS: Record<string, string> = {
+  BidTooLowPenalty: 'BidTooLow',
+  BlacklistPenalty: 'Blacklist',
+  BondRiskFee: 'Bond Risk Fee',
+}
 
 export type ProtectedEvent = {
   epoch: number
@@ -116,14 +115,9 @@ export const selectProtectedStakeReason = (protectedEvent: ProtectedEvent) => {
       return `Uptime ${formatPercentage(reason.DowntimeRevenueImpact.actual_credits / reason.DowntimeRevenueImpact.expected_credits)}`
     }
   }
-  if (isBidTooLowPenalty(protectedEvent.reason)) {
-    return 'BidTooLow'
-  }
-  if (isBlacklistPenalty(protectedEvent.reason)) {
-    return 'Blacklist'
-  }
-  if (isBondRiskFee(protectedEvent.reason)) {
-    return 'Bond Risk Fee'
+  if (typeof protectedEvent.reason === 'string') {
+    const label = PENALTY_LABELS[protectedEvent.reason]
+    if (label) return label
   }
   console.log('unsupported event:', protectedEvent)
   return 'Unsupported'

--- a/src/services/protected-events.ts
+++ b/src/services/protected-events.ts
@@ -75,6 +75,7 @@ export type SettlementReason =
   | 'Bidding'
   | 'BidTooLowPenalty'
   | 'BlacklistPenalty'
+  | 'BondRiskFee'
 
 export const isProtectedEvent = (
   e: SettlementReason,
@@ -84,6 +85,8 @@ export const isBidTooLowPenalty = (e: SettlementReason): boolean =>
   e === 'BidTooLowPenalty'
 export const isBlacklistPenalty = (e: SettlementReason): boolean =>
   e === 'BlacklistPenalty'
+export const isBondRiskFee = (e: SettlementReason): boolean =>
+  e === 'BondRiskFee'
 
 export type ProtectedEvent = {
   epoch: number
@@ -118,6 +121,9 @@ export const selectProtectedStakeReason = (protectedEvent: ProtectedEvent) => {
   }
   if (isBlacklistPenalty(protectedEvent.reason)) {
     return 'Blacklist'
+  }
+  if (isBondRiskFee(protectedEvent.reason)) {
+    return 'Bond Risk Fee'
   }
   console.log('unsupported event:', protectedEvent)
   return 'Unsupported'

--- a/src/services/protected-events.ts
+++ b/src/services/protected-events.ts
@@ -111,7 +111,7 @@ export const selectProtectedStakeReason = (protectedEvent: ProtectedEvent) => {
   }
   if (protectedEvent.reason === 'BidTooLowPenalty') return 'BidTooLow'
   if (protectedEvent.reason === 'BlacklistPenalty') return 'Blacklist'
-  if (protectedEvent.reason === 'BondRiskFee') return 'Bond Risk Fee'
+  if (protectedEvent.reason === 'BondRiskFee') return 'BondRiskFee'
   console.log('unsupported event:', protectedEvent)
   return 'Unsupported'
 }

--- a/src/services/scoring.ts
+++ b/src/services/scoring.ts
@@ -3,6 +3,10 @@ export type ScoringValidator = {
   voteAccount: string
   revShare: {
     bidTooLowPenaltyPmpe: number
+    blacklistPenaltyPmpe: number
+  }
+  values: {
+    bondRiskFeeSol: number
   }
 }
 

--- a/src/services/validator-with-protected_event.ts
+++ b/src/services/validator-with-protected_event.ts
@@ -101,12 +101,6 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
     })
   }
 
-  const pmpeToLamports = (
-    pmpe: number,
-    nativeStake: string,
-    liquidStake: string,
-  ) => ((Number(nativeStake) + Number(liquidStake)) * pmpe) / 1000
-
   const auctionCoversCurrentEpoch = maxStatsEpoch >= maxScoredEpoch
   for (const entry of scoring) {
     if (entry.epoch <= latestProcessedEpoch) continue
@@ -116,14 +110,13 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
       ({ epoch }) => epoch === entry.epoch,
     )
     if (epochStats == null) continue
+    const stake =
+      Number(epochStats.marinade_native_stake ?? '0') +
+      Number(epochStats.marinade_stake ?? '0')
     pushAuctionPenalty(
       entry.voteAccount,
       entry.epoch,
-      pmpeToLamports(
-        entry.revShare.bidTooLowPenaltyPmpe,
-        epochStats.marinade_native_stake ?? '0',
-        epochStats.marinade_stake ?? '0',
-      ),
+      (stake * entry.revShare.bidTooLowPenaltyPmpe) / 1000,
       'BidTooLowPenalty',
     )
   }
@@ -131,18 +124,19 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
   if (auctionCoversCurrentEpoch) {
     for (const entry of auctionResult.auctionData.validators) {
       const v = validatorsMap[entry.voteAccount]
-      const native = v?.marinade_native_stake ?? '0'
-      const liquid = v?.marinade_stake ?? '0'
+      const stake =
+        Number(v?.marinade_native_stake ?? '0') +
+        Number(v?.marinade_stake ?? '0')
       pushAuctionPenalty(
         entry.voteAccount,
         maxStatsEpoch,
-        pmpeToLamports(entry.revShare.bidTooLowPenaltyPmpe, native, liquid),
+        (stake * entry.revShare.bidTooLowPenaltyPmpe) / 1000,
         'BidTooLowPenalty',
       )
       pushAuctionPenalty(
         entry.voteAccount,
         maxStatsEpoch,
-        pmpeToLamports(entry.revShare.blacklistPenaltyPmpe, native, liquid),
+        (stake * entry.revShare.blacklistPenaltyPmpe) / 1000,
         'BlacklistPenalty',
       )
       pushAuctionPenalty(

--- a/src/services/validator-with-protected_event.ts
+++ b/src/services/validator-with-protected_event.ts
@@ -119,6 +119,18 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
       (stake * entry.revShare.bidTooLowPenaltyPmpe) / 1000,
       'BidTooLowPenalty',
     )
+    pushAuctionPenalty(
+      entry.voteAccount,
+      entry.epoch,
+      (stake * entry.revShare.blacklistPenaltyPmpe) / 1000,
+      'BlacklistPenalty',
+    )
+    pushAuctionPenalty(
+      entry.voteAccount,
+      entry.epoch,
+      Math.round((entry.values?.bondRiskFeeSol ?? 0) * 1e9),
+      'BondRiskFee',
+    )
   }
 
   if (auctionCoversCurrentEpoch) {

--- a/src/services/validator-with-protected_event.ts
+++ b/src/services/validator-with-protected_event.ts
@@ -4,7 +4,7 @@ import { loadSam } from './sam'
 import { fetchScoring } from './scoring'
 import { fetchValidatorsWithEpochs } from './validators'
 
-import type { ProtectedEvent } from './protected-events'
+import type { ProtectedEvent, SettlementReason } from './protected-events'
 import type { Validator } from './validators'
 
 export enum ProtectedEventStatus {
@@ -81,29 +81,31 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
     maxScoredEpoch = Math.max(entry.epoch, maxScoredEpoch)
   }
 
-  const pushPenalty = (
+  const pushAuctionPenalty = (
     voteAccount: string,
     epoch: number,
-    nativeStake: string,
-    liquidStake: string,
-    bidTooLowPenaltyPmpe: number,
+    amountLamports: number,
+    reason: SettlementReason,
   ) => {
-    const penalty =
-      ((Number(nativeStake) + Number(liquidStake)) * bidTooLowPenaltyPmpe) /
-      1000
-    if (penalty <= 0) return
+    if (amountLamports <= 0) return
     protectedEventsWithValidator.push({
       status: ProtectedEventStatus.ESTIMATE,
       protectedEvent: {
         epoch,
-        amount: penalty,
+        amount: amountLamports,
         vote_account: voteAccount,
         meta: { funder: 'ValidatorBond' as const },
-        reason: 'BidTooLowPenalty' as const,
+        reason,
       },
       validator: validatorsMap[voteAccount] ?? null,
     })
   }
+
+  const pmpeToLamports = (
+    pmpe: number,
+    nativeStake: string,
+    liquidStake: string,
+  ) => ((Number(nativeStake) + Number(liquidStake)) * pmpe) / 1000
 
   const auctionCoversCurrentEpoch = maxStatsEpoch >= maxScoredEpoch
   for (const entry of scoring) {
@@ -114,24 +116,40 @@ export const fetchProtectedEventsWithValidator = async (): Promise<
       ({ epoch }) => epoch === entry.epoch,
     )
     if (epochStats == null) continue
-    pushPenalty(
+    pushAuctionPenalty(
       entry.voteAccount,
       entry.epoch,
-      epochStats.marinade_native_stake ?? '0',
-      epochStats.marinade_stake ?? '0',
-      entry.revShare.bidTooLowPenaltyPmpe,
+      pmpeToLamports(
+        entry.revShare.bidTooLowPenaltyPmpe,
+        epochStats.marinade_native_stake ?? '0',
+        epochStats.marinade_stake ?? '0',
+      ),
+      'BidTooLowPenalty',
     )
   }
 
   if (auctionCoversCurrentEpoch) {
     for (const entry of auctionResult.auctionData.validators) {
       const v = validatorsMap[entry.voteAccount]
-      pushPenalty(
+      const native = v?.marinade_native_stake ?? '0'
+      const liquid = v?.marinade_stake ?? '0'
+      pushAuctionPenalty(
         entry.voteAccount,
         maxStatsEpoch,
-        v?.marinade_native_stake ?? '0',
-        v?.marinade_stake ?? '0',
-        entry.revShare.bidTooLowPenaltyPmpe,
+        pmpeToLamports(entry.revShare.bidTooLowPenaltyPmpe, native, liquid),
+        'BidTooLowPenalty',
+      )
+      pushAuctionPenalty(
+        entry.voteAccount,
+        maxStatsEpoch,
+        pmpeToLamports(entry.revShare.blacklistPenaltyPmpe, native, liquid),
+        'BlacklistPenalty',
+      )
+      pushAuctionPenalty(
+        entry.voteAccount,
+        maxStatsEpoch,
+        Math.round((entry.values?.bondRiskFeeSol ?? 0) * 1e9),
+        'BondRiskFee',
       )
     }
   }


### PR DESCRIPTION
Extends protected-events list on the dashboard to include all bond-funded SAM penalties, not just BidTooLowPenalty. Reuses the existing ProtectedEvent flow and ESTIMATE badge — SAM penalties are current-epoch auction-applied, never settled via on-chain claims.

- SettlementReason gains BondRiskFee (BlacklistPenalty already existed)
- validator-with-protected_event now emits all three auction penalties from AuctionValidator for the current epoch; factored pushPenalty into a generic pushAuctionPenalty(reason) + pmpeToLamports helper
- selectProtectedStakeReason renders the new Bond Risk Fee label