### PR TITLE
[fix] hide PriorityFee settlements below 0.1 SOL [trivial]

### DIFF
--- a/src/components/protected-events-table/protected-events-table.tsx
+++ b/src/components/protected-events-table/protected-events-table.tsx
@@ -117,7 +117,13 @@ export const ProtectedEventsTable: React.FC<Props> = ({ data, level }) => {
   })
   const filteredData = preFilteredData.filter(
     ({ protectedEvent, validator: _validator }) => {
-      return protectedEvent.reason !== 'Bidding'
+      if (protectedEvent.reason === 'Bidding') return false
+      if (
+        protectedEvent.reason === 'PriorityFee' &&
+        selectAmount(protectedEvent) < 0.1
+      )
+        return false
+      return true
     },
   )
   const lastSettledEpoch = data.reduce(


### PR DESCRIPTION
  Drops PriorityFee rows under 0.1 SOL from the protected-events table.
  Dust-sized priority-fee charges added noise without informational value;
  same pattern as the existing Bidding filter.
