### PR TITLE
[GEN-8704][card] fix displayed winning apy in the validator's card

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,8 +34,11 @@ start:dev`), build output to `build/` (`pnpm build`), preview on 8080
 - **Data**: `@tanstack/react-query` 5.100 (object-form API everywhere).
 - **Markdown**: `react-markdown` 10 + `remark-gfm` + `remark-breaks` +
   `rehype-raw` (for the docs page).
-- **Auction algorithm**: `@marinade.finance/ds-sam-sdk` 0.0.51
-  (`DsSamSDK`, `loadSamConfig`, `runFinalOnly`).
+- **Auction algorithm**: `@marinade.finance/ds-sam-sdk` 0.1.3
+  (`DsSamSDK`, `loadSamConfig`, `runFinalOnly`) plus
+  `@marinade.finance/ds-sam-calc` 0.1.3 (shared pure calc / selectors /
+  tip engine, re-exported through `src/services/*`). Both packages ship
+  from the same `ds-sam` repo and must be bumped together.
 - **Analytics**: `react-gtm-module` initialised in `src/index.tsx`.
 - **Testing**: Vitest 4 (unit, `*.test.{ts,tsx}` under `src/`);
   Playwright 1.60 (e2e, `tests/`).

--- a/SCREENS.md
+++ b/SCREENS.md
@@ -330,10 +330,14 @@ penalties` when total is zero, or the destructive total cost),
   APY carry one of three tones: green when the validator is above the
   winning threshold AND holds SAM stake (`selectInSet`), grey when it
   is above the threshold but holds none (blocked, blacklisted or
-  cap-blocked — the header CTA names the binding reason), destructive
-  when it is below the threshold. Below the threshold the pill becomes
-  a button captioned `Fix in Bidding ↗` that switches the panel to the
-  Bidding tab so the validator sees the concrete target bid.
+  cap-blocked), destructive when it is below the threshold. Each
+  non-green tone adds a caption above the pill, because a signed delta
+  on its own reads as good news. Grey gets a muted, non-clickable
+  `Cleared, but out of set` — the header CTA names which constraint
+  binds, and no bid clears a cap or a block. Destructive gets
+  `Fix in Bidding ↗`, and the whole stack becomes one button that
+  switches the panel to the Bidding tab so the validator sees the
+  concrete target bid.
 - **What-If Simulation** (only when the Simulate switch is on) —
   four numeric inputs: Stake Bid (PMPE), Inflation Commission %,
   MEV Commission %, Block Rewards Commission %. Auto-recalcs with

--- a/SCREENS.md
+++ b/SCREENS.md
@@ -326,9 +326,13 @@ penalties` when total is zero, or the destructive total cost),
   show `N% shared` — the fraction GIVEN to stakers (`1 − commission`,
   and `0%` when the commission is null or ≥ 100%, matching the SDK's
   zeroed `blockPmpe`). Threshold marker line + label at the
-  winning-APY position. The `±X% vs winning` pill is green above
-  the winning threshold; below it the pill becomes a button reading
-  `-X% vs winning → Bidding` that switches the panel to the
+  winning-APY position. The `±X% vs winning` pill and the Total row's
+  APY carry one of three tones: green when the validator is above the
+  winning threshold AND holds SAM stake (`selectInSet`), grey when it
+  is above the threshold but holds none (blocked, blacklisted or
+  cap-blocked — the header CTA names the binding reason), destructive
+  when it is below the threshold. Below the threshold the pill becomes
+  a button captioned `Fix in Bidding ↗` that switches the panel to the
   Bidding tab so the validator sees the concrete target bid.
 - **What-If Simulation** (only when the Simulate switch is on) —
   four numeric inputs: Stake Bid (PMPE), Inflation Commission %,

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "vitest": "4.1.7"
   },
   "dependencies": {
-    "@marinade.finance/ds-sam-calc": "0.1.2",
-    "@marinade.finance/ds-sam-sdk": "0.1.2",
+    "@marinade.finance/ds-sam-calc": "0.1.3",
+    "@marinade.finance/ds-sam-sdk": "0.1.3",
     "@marinade.finance/ts-common": "^4.3.2",
     "@zodios/core": "10.9.6",
     "zod": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ importers:
   .:
     dependencies:
       '@marinade.finance/ds-sam-calc':
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: 0.1.3
+        version: 0.1.3
       '@marinade.finance/ds-sam-sdk':
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: 0.1.3
+        version: 0.1.3
       '@marinade.finance/ts-common':
         specifier: ^4.3.2
         version: 4.3.2
@@ -808,11 +808,11 @@ packages:
   '@liuli-util/fs-extra@0.1.0':
     resolution: {integrity: sha512-eaAyDyMGT23QuRGbITVY3SOJff3G9ekAAyGqB9joAnTBmqvFN+9a1FazOdO70G6IUqgpKV451eBHYSRcOJ/FNQ==}
 
-  '@marinade.finance/ds-sam-calc@0.1.2':
-    resolution: {integrity: sha512-YrfaFsDqPP8J4s7jr9FxQ5/cbYgklLmi+rxHkr5LhC83/gydiz8XhuxBMNDzvlUYgLuY4J2gylLdnKLfS9DoRg==}
+  '@marinade.finance/ds-sam-calc@0.1.3':
+    resolution: {integrity: sha512-SQDosZIOI048ovnn7zpCVWpenAG7Je8xEKobQBiXtmf6pUfvFPn+SR956fStAsAW3XN7mc4YWCP4EKFgJopjDA==}
 
-  '@marinade.finance/ds-sam-sdk@0.1.2':
-    resolution: {integrity: sha512-H8Gf0uCUtXvZq06oz86mwiwJZdi57bJM1F3sA6nFMpTc4pxUQiLxyX/wtRij2LQDBSxVnp24srQqGLNNa1WKyA==}
+  '@marinade.finance/ds-sam-sdk@0.1.3':
+    resolution: {integrity: sha512-18EaBNyTuCdq/l2X9YLUMLejXAZypEcS0zBB/sdU6We+qH1fIrSeKxSo/iMQpGOCnT/nGNWOnLtvfsUBy5B6Dg==}
 
   '@marinade.finance/eslint-config@1.3.5':
     resolution: {integrity: sha512-yKLW2vI9QmQ6uWO3SQSbOYDmtSpYPU34zuomKGCfoLF7/bN+c6GinyzUumIPoUshqztRkqjOpFels4F4E6puEg==}
@@ -1853,6 +1853,9 @@ packages:
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -2582,6 +2585,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -2728,6 +2735,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-from-parse5@8.0.3:
@@ -5421,15 +5432,15 @@ snapshots:
       '@types/fs-extra': 9.0.13
       fs-extra: 10.1.0
 
-  '@marinade.finance/ds-sam-calc@0.1.2':
+  '@marinade.finance/ds-sam-calc@0.1.3':
     dependencies:
       '@marinade.finance/ts-common': 4.3.2
       decimal.js: 10.6.0
 
-  '@marinade.finance/ds-sam-sdk@0.1.2':
+  '@marinade.finance/ds-sam-sdk@0.1.3':
     dependencies:
-      '@marinade.finance/ds-sam-calc': 0.1.2
-      axios: 1.16.1
+      '@marinade.finance/ds-sam-calc': 0.1.3
+      axios: 1.19.0
       decimal.js: 10.6.0
       semver: 7.8.5
     transitivePeerDependencies:
@@ -6450,6 +6461,16 @@ snapshots:
       - debug
       - supports-color
 
+  axios@1.19.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   axobject-query@4.1.0: {}
 
   babel-jest@30.4.1(@babel/core@7.29.7):
@@ -7369,6 +7390,14 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -7518,6 +7547,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 

--- a/src/components/validator-detail/__tests__/apy-composition-card.test.ts
+++ b/src/components/validator-detail/__tests__/apy-composition-card.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { apyStanding, PILL } from '../apy-composition-card'
+
+import type { AuctionValidator } from '@marinade.finance/ds-sam-sdk'
+
+const makeValidator = (marinadeSamTargetSol: number): AuctionValidator =>
+  ({ auctionStake: { marinadeSamTargetSol } }) as unknown as AuctionValidator
+
+describe('apyStanding', () => {
+  it('is below when the total APY misses the threshold', () => {
+    expect(apyStanding(makeValidator(100), -0.004)).toBe('below')
+  })
+
+  it('is winning when the validator clears the threshold and holds stake', () => {
+    expect(apyStanding(makeValidator(100), 0.004)).toBe('winning')
+  })
+
+  it('is outOfSet when the validator clears the threshold with no stake', () => {
+    expect(apyStanding(makeValidator(0), 0.004)).toBe('outOfSet')
+  })
+
+  it('is winning exactly at the threshold', () => {
+    expect(apyStanding(makeValidator(100), 0)).toBe('winning')
+  })
+})
+
+describe('PILL tones', () => {
+  it('never paints an out-of-set validator as a winner', () => {
+    expect(PILL.outOfSet).not.toContain('primary')
+  })
+
+  it('keeps the out-of-set tone distinct from the below-threshold one', () => {
+    expect(PILL.outOfSet).not.toContain('destructive')
+  })
+})

--- a/src/components/validator-detail/__tests__/apy-composition-card.test.ts
+++ b/src/components/validator-detail/__tests__/apy-composition-card.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { apyStanding, PILL } from '../apy-composition-card'
+import { apyStanding } from '../apy-composition-card'
 
 import type { AuctionValidator } from '@marinade.finance/ds-sam-sdk'
 
@@ -22,15 +22,5 @@ describe('apyStanding', () => {
 
   it('is winning exactly at the threshold', () => {
     expect(apyStanding(makeValidator(100), 0)).toBe('winning')
-  })
-})
-
-describe('PILL tones', () => {
-  it('never paints an out-of-set validator as a winner', () => {
-    expect(PILL.outOfSet).not.toContain('primary')
-  })
-
-  it('keeps the out-of-set tone distinct from the below-threshold one', () => {
-    expect(PILL.outOfSet).not.toContain('destructive')
   })
 })

--- a/src/components/validator-detail/apy-composition-card.tsx
+++ b/src/components/validator-detail/apy-composition-card.tsx
@@ -110,6 +110,11 @@ export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
   const delta = apyBreakdown.total - winningApy
   const standing = apyStanding(validator, delta)
   const above = standing !== 'below'
+  const pillClass = cn(
+    'text-xs font-mono font-semibold px-2 py-0.5 rounded-md border',
+    PILL[standing],
+  )
+  const pillText = `${above ? '+' : ''}${pct(delta, 2)} vs winning`
 
   return (
     <CalcCard
@@ -121,17 +126,7 @@ export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
         <p className="text-xs text-muted-foreground">
           Winning APY threshold {pct(winningApy, 2)}
         </p>
-        {above || !onGoToBidding ? (
-          <span
-            className={cn(
-              'text-xs font-mono font-semibold px-2 py-0.5 rounded-md border',
-              PILL[standing],
-            )}
-          >
-            {above ? '+' : ''}
-            {pct(delta, 2)} vs winning
-          </span>
-        ) : (
+        {standing === 'below' && onGoToBidding ? (
           // The pill IS the metric. The action label sits above as an
           // auxiliary hint so the pill chrome stays clean. Whole stack is
           // one click target.
@@ -143,18 +138,23 @@ export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
             <span className="text-2xs text-destructive font-medium leading-none group-hover:underline">
               Fix in Bidding ↗
             </span>
-            <span
-              className={cn(
-                'text-xs font-mono font-semibold px-2 py-0.5 rounded-md border',
-                PILL[standing],
-              )}
-            >
-              {pct(delta, 2)} vs winning
-            </span>
+            <span className={pillClass}>{pillText}</span>
             <span className="sr-only">
               see the target bid on the Bidding tab
             </span>
           </button>
+        ) : standing === 'outOfSet' ? (
+          // A positive delta alone reads as good news, so the caption says in
+          // words what the muted tone says in colour. Not a button — no bid
+          // clears a cap or a block.
+          <span className="flex flex-col items-end gap-0.5">
+            <span className="text-2xs text-muted-foreground font-medium leading-none">
+              Cleared, but out of set
+            </span>
+            <span className={pillClass}>{pillText}</span>
+          </span>
+        ) : (
+          <span className={pillClass}>{pillText}</span>
         )}
       </div>
       <div className="space-y-2">

--- a/src/components/validator-detail/apy-composition-card.tsx
+++ b/src/components/validator-detail/apy-composition-card.tsx
@@ -4,6 +4,7 @@ import { cn } from 'src/class_utils'
 import { CalcCard } from 'src/components/breakdowns/card'
 import { pct } from 'src/format'
 import { blockRewardsSharedFrac } from 'src/services/calculations'
+import { selectInSet } from 'src/services/sam'
 
 import type { AuctionValidator } from '@marinade.finance/ds-sam-sdk'
 import type { ApyBreakdownValue } from 'src/services/tip-engine'
@@ -24,6 +25,27 @@ type Row = {
   swatch: string
   context: string
 }
+
+type Standing = 'winning' | 'outOfSet' | 'below'
+
+export const PILL: Record<Standing, string> = {
+  winning: 'bg-primary-light text-primary border-primary',
+  outOfSet: 'bg-muted text-muted-foreground border-muted-foreground',
+  below: 'bg-destructive-light text-destructive border-destructive',
+}
+
+const TOTAL_TEXT: Record<Standing, string> = {
+  winning: 'text-primary',
+  outOfSet: 'text-muted-foreground',
+  below: 'text-destructive',
+}
+
+// Clearing the threshold is necessary to win, not sufficient — blocked, blacklisted and cap-blocked validators clear it holding no stake.
+export const apyStanding = (
+  validator: AuctionValidator,
+  delta: number,
+): Standing =>
+  delta < 0 ? 'below' : selectInSet(validator) ? 'winning' : 'outOfSet'
 
 export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
   apyBreakdown,
@@ -86,7 +108,8 @@ export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
   const apyScale = Math.max(apyBreakdown.total, winningApy) * 1.2
   const winPct = (winningApy / apyScale) * 100
   const delta = apyBreakdown.total - winningApy
-  const above = delta >= 0
+  const standing = apyStanding(validator, delta)
+  const above = standing !== 'below'
 
   return (
     <CalcCard
@@ -102,9 +125,7 @@ export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
           <span
             className={cn(
               'text-xs font-mono font-semibold px-2 py-0.5 rounded-md border',
-              above
-                ? 'bg-primary-light text-primary border-primary'
-                : 'bg-destructive-light text-destructive border-destructive',
+              PILL[standing],
             )}
           >
             {above ? '+' : ''}
@@ -122,7 +143,12 @@ export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
             <span className="text-2xs text-destructive font-medium leading-none group-hover:underline">
               Fix in Bidding ↗
             </span>
-            <span className="text-xs font-mono font-semibold px-2 py-0.5 rounded-md border bg-destructive-light text-destructive border-destructive">
+            <span
+              className={cn(
+                'text-xs font-mono font-semibold px-2 py-0.5 rounded-md border',
+                PILL[standing],
+              )}
+            >
               {pct(delta, 2)} vs winning
             </span>
             <span className="sr-only">
@@ -194,7 +220,7 @@ export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
           <span
             className={cn(
               'text-xs font-mono font-semibold w-12 text-right shrink-0',
-              above ? 'text-primary' : 'text-destructive',
+              TOTAL_TEXT[standing],
             )}
           >
             {pct(apyBreakdown.total, 2)}

--- a/src/components/validator-detail/apy-composition-card.tsx
+++ b/src/components/validator-detail/apy-composition-card.tsx
@@ -109,12 +109,11 @@ export const ApyCompositionCard: React.FC<ApyCompositionCardProps> = ({
   const winPct = (winningApy / apyScale) * 100
   const delta = apyBreakdown.total - winningApy
   const standing = apyStanding(validator, delta)
-  const above = standing !== 'below'
   const pillClass = cn(
     'text-xs font-mono font-semibold px-2 py-0.5 rounded-md border',
     PILL[standing],
   )
-  const pillText = `${above ? '+' : ''}${pct(delta, 2)} vs winning`
+  const pillText = `${delta > 0 ? '+' : ''}${pct(delta, 2)} vs winning`
 
   return (
     <CalcCard

--- a/src/components/validator-detail/validator-detail.tsx
+++ b/src/components/validator-detail/validator-detail.tsx
@@ -57,7 +57,7 @@ import {
   selectRedelegationPriorityFrontierPmpe,
   selectValidatorConcentration,
   selectVoteAccount,
-  selectWinningApyForValidator,
+  selectWinningAPY,
 } from 'src/services/sam'
 import {
   bondAdvice,
@@ -609,12 +609,7 @@ export const ValidatorDetail = ({
   const voteAccount = selectVoteAccount(validator)
   const validatorName = nameMap?.get(voteAccount)?.name
   const notificationSummary = notificationsMap?.[voteAccount]
-  const winningApy = selectWinningApyForValidator(
-    validator,
-    auctionResult,
-    epochsPerYear,
-    dsSamConfig.minBondBalanceSol,
-  )
+  const winningApy = selectWinningAPY(auctionResult, epochsPerYear)
   const winningTotalPmpe = auctionResult.winningTotalPmpe
   const apyBreakdown = getApyBreakdown(validator, epochsPerYear)
   const bondHealth = bondHealthFromAuction(

--- a/src/services/__tests__/sam.test.ts
+++ b/src/services/__tests__/sam.test.ts
@@ -12,7 +12,7 @@ import {
   selectRedelegationPriorityFrontierPmpe,
   selectRedelegationPriorityRank,
   selectValidatorConcentration,
-  selectWinningApyForValidator,
+  selectWinningAPY,
 } from '../sam'
 
 import { compoundApy } from '../calculations'
@@ -372,37 +372,21 @@ describe('allocateRedelegation — best-first walk by totalPmpe desc', () => {
 function makeApyValidator(
   voteAccount: string,
   totalPmpe: number,
-  nonBid: number,
-  inSet: boolean,
 ): AuctionValidator {
   return {
     voteAccount,
-    auctionStake: { marinadeSamTargetSol: inSet ? 100 : 0 },
-    marinadeActivatedStakeSol: 0,
-    bondBalanceSol: 5,
-    values: { paidUndelegationSol: 0 },
-    revShare: { totalPmpe, inflationPmpe: nonBid, mevPmpe: 0, blockPmpe: 0 },
+    revShare: { totalPmpe },
   } as unknown as AuctionValidator
 }
 
-describe('selectWinningApyForValidator — marginal winner', () => {
-  it('rebuilds the bid from the LOWEST-totalPmpe in-set validator', () => {
-    // In-set: HIGH (totalPmpe 12) and MARG (totalPmpe 10, the clearing winner).
-    // OUT (totalPmpe 8) is not in set. The bid component must come from MARG's
-    // non-bid profile (nonBid=3), not HIGH's (nonBid=7) or OUT's. Input order
-    // is worst-first so a worst-first walk would wrongly pick HIGH last.
+describe('selectWinningAPY', () => {
+  it('compounds the clearing price and is independent of any validator', () => {
     const result = makeResult(10, [
-      makeApyValidator('OUT', 8, 1, false),
-      makeApyValidator('MARG', 10, 3, true),
-      makeApyValidator('HIGH', 12, 7, true),
+      makeApyValidator('OUT', 8),
+      makeApyValidator('MARG', 10),
+      makeApyValidator('HIGH', 12),
     ])
-    const self = makeApyValidator('SELF', 11, 5, true)
-    const epochsPerYear = 160
-    const winningBidPmpe = Math.max(0, 10 - 3) // winningTotalPmpe − MARG nonBid
-    const expected = compoundApy(5 + winningBidPmpe, epochsPerYear)
-    expect(
-      selectWinningApyForValidator(self, result, epochsPerYear, 0),
-    ).toBeCloseTo(expected, 9)
+    expect(selectWinningAPY(result, 160)).toBeCloseTo(compoundApy(10, 160), 9)
   })
 })
 

--- a/src/services/help-text.ts
+++ b/src/services/help-text.ts
@@ -7,7 +7,7 @@ export const HELP_TEXT = {
   staticBid:
     'Extra yearly return you pay stakers out of your own pocket — added on top of normal validator rewards. This is the main knob to climb the ranking. The cost comes out of your bond each epoch.',
   winningApy:
-    'The lowest yearly return that still won stake this epoch. Your Max APY has to clear this level — beat it and you receive stake, fall short and you don’t.',
+    'The lowest yearly return that still won stake this epoch. Your Max APY has to clear this level — fall short and you receive no stake. Clearing it is necessary but not enough on its own: a block, a blacklist, or a full cap can still leave you out.',
   want: 'The cap you set on how much stake you’ll take. Set it too low and you miss out on stake you could have earned.',
   bondHealth:
     'How well your bond covers the upcoming bid costs. Critical — too thin, fee penalties already kicking in. Watch — too thin to keep current stake; some will be pulled back unless you top up. Adequate — covers current stake but below the ideal buffer; no fee risk yet, topping up unlocks room for more stake. Healthy — comfortably covers what you’ll owe.',

--- a/src/services/sam.ts
+++ b/src/services/sam.ts
@@ -132,7 +132,6 @@ export const selectSamDistributedStake = (validators: AuctionValidator[]) =>
     0,
   )
 
-// Clearing it is necessary to win, not sufficient — blocked and capped validators clear it too.
 export const selectWinningAPY = (
   auctionResult: AuctionResult,
   epochsPerYear: number,

--- a/src/services/sam.ts
+++ b/src/services/sam.ts
@@ -5,12 +5,10 @@ import {
   LogVerbosity,
 } from '@marinade.finance/ds-sam-sdk'
 import {
-  allocateRedelegation,
   annualize,
   compoundApy,
   EPOCHS_PER_YEAR,
   pmpeToSol,
-  selectNonBidPmpe,
 } from '@marinade.finance/ds-sam-calc'
 
 import { pct } from 'src/format'
@@ -134,33 +132,11 @@ export const selectSamDistributedStake = (validators: AuctionValidator[]) =>
     0,
   )
 
+// Clearing it is necessary to win, not sufficient — blocked and capped validators clear it too.
 export const selectWinningAPY = (
   auctionResult: AuctionResult,
   epochsPerYear: number,
 ) => compoundApy(auctionResult.winningTotalPmpe, epochsPerYear)
-
-// Rebuild the winning APY at THIS validator's commission profile: take the
-// marginal winner's bid component and add it to the validator's own
-// inflation/MEV/block revenue. Answers "would I clear at the auction-
-// clearing bid?" — apples-to-apples for the APY pill in validator-detail.
-export function selectWinningApyForValidator(
-  v: AuctionValidator,
-  auctionResult: AuctionResult,
-  epochsPerYear: number,
-  minBondBalanceSol: number,
-): number {
-  const { marginalWinner } = allocateRedelegation(
-    auctionResult,
-    minBondBalanceSol,
-  )
-  const winningBidPmpe = marginalWinner
-    ? Math.max(
-        0,
-        auctionResult.winningTotalPmpe - selectNonBidPmpe(marginalWinner),
-      )
-    : 0
-  return compoundApy(selectNonBidPmpe(v) + winningBidPmpe, epochsPerYear)
-}
 
 const totalProfitPmpe = (v: AuctionValidator) =>
   v.revShare.auctionEffectiveBidPmpe +

--- a/tests/fixture-states.spec.ts
+++ b/tests/fixture-states.spec.ts
@@ -74,6 +74,23 @@ test('VCAP (out-of-set at ASO cap) row tip names the binding constraint', async 
   await expect(row.getByText(/OVH SAS at ASO cap/i).first()).toBeVisible()
 })
 
+test('VCAP APY Composition pill is not painted as a winner', async ({
+  page,
+}) => {
+  await page.goto(`/test-?v=${VCAP}`)
+  await page.waitForSelector('tbody tr', { timeout: 30000 })
+  await expect(page.locator(SHEET).first()).toBeVisible({ timeout: 10000 })
+  // The fixture's totalPmpe 7.5 clears the winning 6.0 yet the ASO cap leaves it zero stake.
+  const pill = page
+    .locator(SHEET)
+    .getByText(/vs winning/)
+    .first()
+  await expect(pill).toBeVisible()
+  const cls = (await pill.getAttribute('class')) ?? ''
+  expect(cls).toMatch(/muted/i)
+  expect(cls).not.toMatch(/primary/i)
+})
+
 test('V08 (Out of Set) row carries the destructive out-of-set tint', async ({
   page,
 }) => {

--- a/tests/fixture-states.spec.ts
+++ b/tests/fixture-states.spec.ts
@@ -89,6 +89,9 @@ test('VCAP APY Composition pill is not painted as a winner', async ({
   const cls = (await pill.getAttribute('class')) ?? ''
   expect(cls).toMatch(/muted/i)
   expect(cls).not.toMatch(/primary/i)
+  // Scoped to the pill's own stack — the sheet header carries an unrelated
+  // "Out of Set" badge that would satisfy a sheet-wide match.
+  await expect(pill.locator('..').getByText(/cleared/i)).toBeVisible()
 })
 
 test('V08 (Out of Set) row carries the destructive out-of-set tint', async ({


### PR DESCRIPTION
It depends on https://github.com/marinade-finance/ds-sam/pull/132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated APY composition indicators to distinguish winning, below-threshold, and out-of-set validators.
  * Added a `Fix in Bidding ↗` action for below-threshold APY values.
  * Added explanatory captions for validators cleared but not receiving stake.

* **Bug Fixes**
  * Improved winning APY calculations to consistently reflect the auction clearing price.
  * Clarified that meeting the winning threshold may not guarantee stake allocation due to limits or exclusions.

* **Documentation**
  * Updated auction calculation package references and architecture documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->